### PR TITLE
fix: segfaults with see3cam

### DIFF
--- a/common/see3cam_cu40.h
+++ b/common/see3cam_cu40.h
@@ -279,7 +279,8 @@ private:
                     // Read Bayer pixels
                     const uint16_t b = *(inBG16Start++);
                     const uint16_t g = *(inBG16Start++);
-                    const uint16_t r = *(inR16Start += 2);
+                    const uint16_t r = *inR16Start;
+                    inR16Start += 2;
 
                     // Write back to BGR
                     *(outRGBStart++) = T::getB(r, g, b);

--- a/common/v4l_camera.h
+++ b/common/v4l_camera.h
@@ -42,6 +42,10 @@ public:
                 std::cerr << "ERROR: Cannot stop streaming (" << strerror(errno) << ")" << std::endl;
             }
 
+            // munmap buffers
+            if (-1 == munmap(m_Buffer[0], m_BufferInfo[0].length) || -1 == munmap(m_Buffer[1], m_BufferInfo[1].length))
+                std::cerr << "ERROR: Could not free buffers (" << strerror(errno) << ")" << std::endl;
+
             // Close camera
             close(m_Camera);
         }


### PR DESCRIPTION
If I close the camera (delete the object) and reopen it in the same process I get a segfault as soon as I try to read a frame.

I've made two small changes which fix this:
- munmap the v4l buffers in the destructor
- fix an off-by-2 pointer in the see3cam header