### PR TITLE
Unwrap serialization

### DIFF
--- a/imgproc/opencv_unwrap_360.h
+++ b/imgproc/opencv_unwrap_360.h
@@ -7,11 +7,11 @@
 // OpenCV includes
 #include <opencv2/opencv.hpp>
 
+//----------------------------------------------------------------------------
+// GeNNRobotics::ImgProc::OpenCVUnwrap360
+//----------------------------------------------------------------------------
 namespace GeNNRobotics {
 namespace ImgProc {
-//----------------------------------------------------------------------------
-// OpenCVUnwrap360
-//----------------------------------------------------------------------------
 class OpenCVUnwrap360
 {
 public:
@@ -109,8 +109,9 @@ public:
     /*
      * Serialise this object.
      */
-    OpenCVUnwrap360 &operator>>(cv::FileStorage &fs)
+    void write(cv::FileStorage& fs) const
     {
+        fs << "{";
         // centre
         cv::Point2d centre = {
             (double) m_CentrePixel.x / (double) m_CameraResolution.width,
@@ -127,8 +128,7 @@ public:
         // other
         fs << "offsetDegrees" << m_OffsetDegrees;
         fs << "flip" << m_Flip;
-
-        return *this;
+        fs << "}";
     }
 
     /*
@@ -136,7 +136,7 @@ public:
      * 
      * **TODO**: Check that we are actually reading values from the file
      */
-    cv::FileStorage &operator<<(cv::FileStorage &fs)
+    void read(const cv::FileNode &node)
     {
         /*
          * We need to already know the camera resolution otherwise we won't be
@@ -147,16 +147,16 @@ public:
         
         // centre
         std::vector<double> centre(2);
-        fs["centre"] >> centre;
+        node["centre"] >> centre;
 
         // inner and outer radius
-        double inner = (double) fs["inner"];
-        double outer = (double) fs["outer"];
+        double inner = (double) node["inner"];
+        double outer = (double) node["outer"];
 
         // other params
-        int offsetDegrees = (int) fs["offsetDegrees"];
+        int offsetDegrees = (int) node["offsetDegrees"];
         bool flip;
-        fs["flip"] >> flip;
+        node["flip"] >> flip;
 
         // create our unwrap maps
         create(m_CameraResolution,
@@ -167,8 +167,6 @@ public:
                outer,
                offsetDegrees,
                flip);
-        
-        return fs;
     }
 
     // Public members
@@ -186,5 +184,22 @@ private:
     cv::Mat m_UnwrapMapX;
     cv::Mat m_UnwrapMapY;
 }; // OpenCVUnwrap360
+
+inline void write(cv::FileStorage &fs, const std::string&, const OpenCVUnwrap360 &config)
+{
+    config.write(fs);
+}
+
+inline void read(const cv::FileNode &node, OpenCVUnwrap360 &x, OpenCVUnwrap360 defaultValue = OpenCVUnwrap360())
+{
+    if(node.empty()) {
+        x = defaultValue;
+    }
+    else {
+        x.read(node);
+    }
+}
+
+
 }  // ImgProc
 }  // GeNNRobotics

--- a/imgproc/tests/deserialise/test.cc
+++ b/imgproc/tests/deserialise/test.cc
@@ -3,20 +3,20 @@
 #include <memory>
 
 // GeNNRobotics includes
-#include "common/opencv_unwrap_360.h"
+#include "imgproc/opencv_unwrap_360.h"
 
-int
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     // create unwrapper object for a camera of specified resolution
     cv::Size cameraResolution(1280, 400);
-    OpenCVUnwrap360 unwrapper(cameraResolution);
+    cv::Size unwrapResolution(180, 50);
+    GeNNRobotics::ImgProc::OpenCVUnwrap360 unwrapper(cameraResolution, unwrapResolution);
 
     // open file containing unwrap params
     cv::FileStorage fs("deserialise_test.yaml", cv::FileStorage::READ);
 
-    // read params from file
-    unwrapper << fs;
+    // read params from root node of file
+    fs["unwrapper"] >> unwrapper;
 
     // close file
     fs.release();

--- a/imgproc/tests/deserialise_test.yaml
+++ b/imgproc/tests/deserialise_test.yaml
@@ -1,8 +1,8 @@
 %YAML:1.0
 ---
-unwrappedResolution: [ 1280, 400 ]
-centre: [ 4.5468750000000002e-01, 2.0499999999999999e-01 ]
-inner: 8.7499999999999994e-02
-outer: 1.9000000000000000e-01
-offsetDegrees: 0
-flip: 0
+unwrapper:
+    centre: [ 4.5468750000000002e-01, 2.0499999999999999e-01 ]
+    inner: 8.7499999999999994e-02
+    outer: 1.9000000000000000e-01
+    offsetDegrees: 0
+    flip: 0

--- a/imgproc/tests/serialise/test.cc
+++ b/imgproc/tests/serialise/test.cc
@@ -2,20 +2,20 @@
 #include <iostream>
 
 // GeNNRobotics includes
-#include "common/opencv_unwrap_360.h"
+#include "imgproc/opencv_unwrap_360.h"
 
 int
 main(int argc, char **argv)
 {
     // create new unwrapper with desired params
-    OpenCVUnwrap360 unwrapper(cv::Size(1280, 720),
-                              cv::Size(1280, 400),
-                              0.45468750000000002,
-                              0.20499999999999999,
-                              0.087499999999999994,
-                              0.19,
-                              0,
-                              false);
+    GeNNRobotics::ImgProc::OpenCVUnwrap360 unwrapper(cv::Size(1280, 720),
+                                                     cv::Size(1280, 400),
+                                                     0.45468750000000002,
+                                                     0.20499999999999999,
+                                                     0.087499999999999994,
+                                                     0.19,
+                                                     0,
+                                                     false);
 
     // open file for writing
     const std::string fileName = "serialise_test.yaml";
@@ -23,7 +23,7 @@ main(int argc, char **argv)
     cv::FileStorage fs(fileName, cv::FileStorage::WRITE);
 
     // write unwrap parameters to file
-    unwrapper >> fs;
+    fs << "unwrapper" << unwrapper;
 
     // close file
     fs.release();

--- a/imgproc/unwrapconfig_src/unwrapconfig.cc
+++ b/imgproc/unwrapconfig_src/unwrapconfig.cc
@@ -167,7 +167,7 @@ main(int argc, char **argv)
                 pcam->getCameraName() + ".yaml"; // I don't like this
         std::cout << "Writing to " << filePath << "..." << std::endl;
         cv::FileStorage outfs(filePath, cv::FileStorage::WRITE);
-        unwrapper >> outfs;
+        outfs << "unwrapper" << unwrapper;
         outfs.release();
     }
 

--- a/imgproc/unwrapparams/pixpro_usb.yaml
+++ b/imgproc/unwrapparams/pixpro_usb.yaml
@@ -1,7 +1,8 @@
 %YAML:1.0
 ---
-centre: [0.506944, 0.510417]
-inner: 0
-outer: 0.541667
-offsetDegrees: 0
-flip: 0
+unwrapper:
+    centre: [0.506944, 0.510417]
+    inner: 0
+    outer: 0.541667
+    offsetDegrees: 0
+    flip: 0

--- a/imgproc/unwrapparams/pixpro_wifi.yaml
+++ b/imgproc/unwrapparams/pixpro_wifi.yaml
@@ -1,7 +1,8 @@
 %YAML:1.0
 ---
-centre: [0.5, 0.524414]
-inner: 0.0244141
-outer: 0.5
-offsetDegrees: 0
-flip: 0
+unwrapper:
+    centre: [0.5, 0.524414]
+    inner: 0.0244141
+    outer: 0.5
+    offsetDegrees: 0
+    flip: 0

--- a/imgproc/unwrapparams/see3cam.yaml
+++ b/imgproc/unwrapparams/see3cam.yaml
@@ -1,7 +1,8 @@
 %YAML:1.0
 ---
-centre: [0.49375, 0.461111]
-inner: 0.183333
-outer: 0.408333
-offsetDegrees: -90
-flip: 1
+unwrapper:
+    centre: [0.49375, 0.461111]
+    inner: 0.183333
+    outer: 0.408333
+    offsetDegrees: -90
+    flip: 1

--- a/imgproc/unwrapparams/webcam360.yaml
+++ b/imgproc/unwrapparams/webcam360.yaml
@@ -1,7 +1,8 @@
 %YAML:1.0
 ---
-centre: [0.454861, 0.204861]
-inner: 0.0868056
-outer: 0.190972
-offsetDegrees: 0
-flip: 0
+unwrapper:
+    centre: [0.454861, 0.204861]
+    inner: 0.0868056
+    outer: 0.190972
+    offsetDegrees: 0
+    flip: 0

--- a/video/input.h
+++ b/video/input.h
@@ -64,7 +64,7 @@ public:
         // read unwrap parameters from file
         std::cout << "Loading unwrap parameters from " << filePath.str() << std::endl;
         cv::FileStorage fs(filePath.str(), cv::FileStorage::READ);
-        unwrapper << fs;
+        fs["unwrapper"] >> unwrapper;
         fs.release();
         return unwrapper;
     }


### PR DESCRIPTION
In order to support serialising it as part of some larger settings yaml I needed to update the way the ``OpenCVUnwrap360`` class was serialized so it players nicer with the (somewhat gross) OpenCV serialisation system.  However this means you don't seem to be able to serialise objects into the root of a YAML document which meant updating the existing yaml files etc, but now means you can do stuff like this:

```c++
cv::FileStorage settingsFile("experiment_settings.yaml", cv::FileStorage::WRITE);
settingsFile << "localUnwrapper" << m_Unwrapper;
settingsFile << "fov" << m_FOV;
```