### PR TITLE
Renaming

### DIFF
--- a/camera_360_test/camera_360_test.cc
+++ b/camera_360_test/camera_360_test.cc
@@ -21,7 +21,7 @@ int main()
 
     // Create panoramic camera and suitable unwrapper
     auto cam = getPanoramicCamera();
-    auto unwrapper = cam->createDefaultUnwrapper(unwrapRes);
+    auto unwrapper = cam->createUnwrapper(unwrapRes);
     const auto cameraRes = cam->getOutputSize();
 
     // Create images

--- a/camera_recorder/camera_recorder.cc
+++ b/camera_recorder/camera_recorder.cc
@@ -4,7 +4,7 @@
 // GeNN robotics includes
 #include "../common/joystick.h"
 #include "../imgproc/opencv_unwrap_360.h"
-#include "../robots/motor_i2c.h"
+#include "../robots/norbot.h"
 #include "../vicon/capture_control.h"
 #include "../vicon/udp.h"
 #include "../video/see3cam_cu40.h"
@@ -39,7 +39,7 @@ int main()
     auto unwrapper = cam.createUnwrapper(unwrapSize);
     
     // Create motor interface
-    MotorI2C motor;
+    Norbot motor;
 
     cv::Mat output(cam.getSuperPixelSize(), CV_8UC1);
     cv::Mat unwrapped(unwrapSize, CV_8UC1);

--- a/camera_recorder/camera_recorder.cc
+++ b/camera_recorder/camera_recorder.cc
@@ -36,7 +36,7 @@ int main()
     Joystick joystick;
 
     // Create unwrapper to unwrap camera output
-    auto unwrapper = cam.createDefaultUnwrapper(unwrapSize);
+    auto unwrapper = cam.createUnwrapper(unwrapSize);
     
     // Create motor interface
     MotorI2C motor;

--- a/common/joystick.h
+++ b/common/joystick.h
@@ -18,7 +18,7 @@
 #include <linux/joystick.h>
 
 // GeNN robotics includes
-#include "../robots/motor.h"
+#include "../robots/tank.h"
 
 using namespace GeNNRobotics::Robots;
 
@@ -156,7 +156,7 @@ public:
         return (float)m_AxisState[axis] / (float)std::numeric_limits<int16_t>::max();
     }
 
-    void drive(Motor &motor, float deadzone)
+    void drive(Tank &motor, float deadzone)
     {
         constexpr float pi = 3.141592653589793238462643383279502884f;
         constexpr float halfPi = pi / 2.0f;

--- a/imgproc/unwrapconfig_src/unwrapconfig.cc
+++ b/imgproc/unwrapconfig_src/unwrapconfig.cc
@@ -48,7 +48,7 @@ main(int argc, char **argv)
 
     // create unwrapper and load params from file
     const cv::Size unwrapRes(1280, 400);
-    ImgProc::OpenCVUnwrap360 unwrapper = pcam->createDefaultUnwrapper(unwrapRes);
+    ImgProc::OpenCVUnwrap360 unwrapper = pcam->createUnwrapper(unwrapRes);
 
     int pixelJump = BIG_PX_JUMP; // number of pixels to move by for
                                  // calibration (either 1 or 5)

--- a/joystick_test/joystick_test.cc
+++ b/joystick_test/joystick_test.cc
@@ -1,5 +1,5 @@
 #include "../common/joystick.h"
-#include "../robots/motor_i2c.h"
+#include "../robots/norbot.h"
 
 int main()
 {
@@ -9,7 +9,7 @@ int main()
     GeNNRobotics::Joystick joystick;
     
     // Create motor interface
-    GeNNRobotics::Robots::MotorI2C motor;
+    GeNNRobotics::Robots::Norbot motor;
 
     do {
         // Read joystick

--- a/net/server.h
+++ b/net/server.h
@@ -9,7 +9,7 @@
 #include <opencv2/opencv.hpp>
 
 // GeNN robotics includes
-#include "../robots/motor.h"
+#include "../robots/tank.h"
 #include "../video/input.h"
 
 // local includes

--- a/optical_flow_test/optical_flow_test.cc
+++ b/optical_flow_test/optical_flow_test.cc
@@ -42,7 +42,7 @@ int main()
 
     // Create panoramic camera and suitable unwrapper
     auto cam = getPanoramicCamera();
-    auto unwrapper = cam->createDefaultUnwrapper(unwrapRes);
+    auto unwrapper = cam->createUnwrapper(unwrapRes);
     const auto camRes = cam->getOutputSize();
 
     // Create optical flow calculator

--- a/robot_net_test/computer.cc
+++ b/robot_net_test/computer.cc
@@ -14,7 +14,7 @@
 #include "hid/joystick.h"
 #include "net/client.h"
 #include "os/net.h"
-#include "robots/motor_netsink.h"
+#include "robots/tank_netsink.h"
 #include "video/display.h"
 #include "video/netsource.h"
 
@@ -49,9 +49,9 @@ main(int argc, char **argv)
         Video::NetSource video(client);
 
         // transmit motor commands over network
-        Robots::MotorNetSink motor(client);
+        Robots::TankNetSink motor(client);
 
-        // add joystick for controlling Motor
+        // add joystick for controlling Tank
         HID::Joystick joystick;
         motor.addJoystick(joystick); // send joystick events to motor
 

--- a/robot_net_test/robot.cc
+++ b/robot_net_test/robot.cc
@@ -19,11 +19,11 @@
 // GeNN robotics includes
 #include "net/server.h"
 #include "os/net.h"
-#include "robots/motor.h"
+#include "robots/tank.h"
 #include "video/panoramic.h"
 
 #ifndef NO_I2C_ROBOT
-#include "robots/motor_i2c.h"
+#include "robots/norbot.h"
 #endif
 
 using namespace GeNNRobotics;
@@ -43,10 +43,10 @@ main()
 
 #ifdef NO_I2C_ROBOT
     // output motor commands to terminal
-    Robots::Motor motor;
+    Robots::Tank motor;
 #else
     // use Arduino robot
-    Robots::MotorI2C motor;
+    Robots::Norbot motor;
 #endif
 
     // read motor commands from network

--- a/robots/norbot.h
+++ b/robots/norbot.h
@@ -9,24 +9,24 @@
 
 // Common includes
 #include "../common/i2c_interface.h"
-#include "motor.h"
+#include "tank.h"
 
 namespace GeNNRobotics {
 namespace Robots {
 //----------------------------------------------------------------------------
-// MotorI2C
+// GeNNRobotics::Robots::Norbot
 //----------------------------------------------------------------------------
-class MotorI2C : public Motor
+class Norbot : public Tank
 {
 public:
-    MotorI2C(const char *path = "/dev/i2c-1", int slaveAddress = 0x29)
+    Norbot(const char *path = "/dev/i2c-1", int slaveAddress = 0x29)
       : m_I2C(path, slaveAddress)
       , m_Left(0.0f)
       , m_Right(0.0f)
     {}
 
     //----------------------------------------------------------------------------
-    // Motor virtuals
+    // Tank virtuals
     //----------------------------------------------------------------------------
     virtual void tank(float left, float right) override
     {
@@ -83,6 +83,6 @@ private:
     GeNNRobotics::I2CInterface m_I2C;
     float m_Left;
     float m_Right;
-}; // MotorI2C
+}; // Norbot
 } // Robots
 } // GeNNRobotics

--- a/robots/surveyor.h
+++ b/robots/surveyor.h
@@ -17,17 +17,17 @@
 #endif
 
 // GeNN robotics includes
-#include "motor.h"
+#include "tank.h"
 
 namespace GeNNRobotics {
 namespace Robots {
 //----------------------------------------------------------------------------
-// MotorSurveyor
+// GeNNRobotics::Robots::Surveyor
 //----------------------------------------------------------------------------
-class MotorSurveyor : public Motor
+class Surveyor : public Tank
 {
 public:
-    MotorSurveyor(const std::string &address, unsigned int port)
+    Surveyor(const std::string &address, unsigned int port)
     {
         // Create socket
         m_Socket = socket(AF_INET, SOCK_STREAM, 0);
@@ -50,7 +50,7 @@ public:
         }
     }
 
-    ~MotorSurveyor()
+    ~Surveyor()
     {
         if (m_Socket > 0) {
             close(m_Socket);
@@ -58,7 +58,7 @@ public:
     }
 
     //----------------------------------------------------------------------------
-    // Motor virtuals
+    // Tank virtuals
     //----------------------------------------------------------------------------
     virtual void tank(float left, float right) override
     {
@@ -85,6 +85,6 @@ private:
     // Private members
     //----------------------------------------------------------------------------
     int m_Socket;
-}; // MotorSurveyor
+}; // Surveyor
 } // Robots
 } // GeNNRobotics

--- a/robots/tank.h
+++ b/robots/tank.h
@@ -10,13 +10,13 @@
 namespace GeNNRobotics {
 namespace Robots {
 //----------------------------------------------------------------------------
-// Motor
+// GeNNRobotics::Robots::Tank
 //----------------------------------------------------------------------------
 // Interface for driving tank-like wheeled robots
-class Motor
+class Tank
 {
 public:
-    virtual ~Motor()
+    virtual ~Tank()
     {}
 
     void addJoystick(HID::Joystick &joystick)
@@ -98,6 +98,6 @@ private:
         // signal that we have handled the event
         return true;
     }
-}; // Motor
+}; // Tank
 } // Robots
 } // GeNNRobotics

--- a/robots/tank_netsink.h
+++ b/robots/tank_netsink.h
@@ -4,14 +4,17 @@
 #include "../net/node.h"
 
 // local includes
-#include "motor.h"
+#include "tank.h"
 
 namespace GeNNRobotics {
 namespace Robots {
-class MotorNetSink : public Motor
+//----------------------------------------------------------------------------
+// GeNNRobotics::Robots::TankNetSink
+//----------------------------------------------------------------------------
+class TankNetSink : public Tank
 {
 public:
-    MotorNetSink(Net::Node &node)
+    TankNetSink(Net::Node &node)
       : m_Node(&node)
     {}
 

--- a/see3cam_test/see3cam_test.cc
+++ b/see3cam_test/see3cam_test.cc
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     const unsigned int unwrapHeight = 140;
 
     Mode mode = Mode::Greyscale;
-    OpenCVUnwrap360 unwrapper = cam.createDefaultUnwrapper(unwrapWidth, unwrapHeight);
+    OpenCVUnwrap360 unwrapper = cam.createUnwrapper(unwrapWidth, unwrapHeight);
     
     auto autoExposureMask = cam.createBubblescopeMask(cv::Size(rawWidth, rawHeight));
 

--- a/stone_cx/robotCommon.cc
+++ b/stone_cx/robotCommon.cc
@@ -5,12 +5,12 @@
 #include <numeric>
 
 // Common includes
-#include "../robots/motor_i2c.h"
+#include "../robots/norbot.h"
 
 // GeNN generated code includes
 #include "stone_cx_CODE/definitions.h"
 
-float driveMotorFromCPU1(GeNNRobotics::Robots::MotorI2C &motor, bool display)
+float driveMotorFromCPU1(GeNNRobotics::Robots::Norbot &motor, bool display)
 {
     // Sum left and right motor activity
     const float leftMotor = std::accumulate(&rCPU1[0], &rCPU1[8], 0.0f);

--- a/stone_cx/robotCommon.h
+++ b/stone_cx/robotCommon.h
@@ -3,9 +3,9 @@
 namespace GeNNRobotics {
 namespace Robots {
 // Forward declarations
-class MotorI2C;
+class Norbot;
 }
 }
 
 // Functions
-float driveMotorFromCPU1(GeNNRobotics::Robots::MotorI2C &motor, bool display = false);
+float driveMotorFromCPU1(GeNNRobotics::Robots::Norbot &motor, bool display = false);

--- a/stone_cx/simulatorRobot.cc
+++ b/stone_cx/simulatorRobot.cc
@@ -77,7 +77,7 @@ void opticalFlowThreadFunc(int cameraDevice, std::atomic<bool> &shouldQuit, std:
 
     // Create unwrapper to unwrap camera output
     const cv::Size camRes = cam.getOutputSize();
-    auto unwrapper = cam.createDefaultUnwrapper(unwrapRes);
+    auto unwrapper = cam.createUnwrapper(unwrapRes);
 #else
     // Open video capture device and check it matches desired camera resolution
     cv::VideoCapture capture(cameraDevice);

--- a/stone_cx/simulatorRobot.cc
+++ b/stone_cx/simulatorRobot.cc
@@ -9,7 +9,7 @@
 #include "../common/timer.h"
 #include "../imgproc/opencv_optical_flow.h"
 #include "../imgproc/opencv_unwrap_360.h"
-#include "../robots/motor_i2c.h"
+#include "../robots/norbot.h"
 #include "../video/see3cam_cu40.h"
 
 // GeNN generated code includes
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     Joystick joystick;
     
     // Create motor interface
-    MotorI2C motor;
+    Norbot motor;
     
     // Initialise GeNN
     allocateMem();

--- a/stone_cx/simulatorRobotDeadReckon.cc
+++ b/stone_cx/simulatorRobotDeadReckon.cc
@@ -8,7 +8,7 @@
 #include "../common/joystick.h"
 #include "../common/lm9ds1_imu.h"
 #include "../common/timer.h"
-#include "../robots/motor_i2c.h"
+#include "../robots/norbot.h"
 
 // GeNN generated code includes
 #include "stone_cx_CODE/definitions.h"
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     Joystick joystick;
     
     // Create motor interface
-    Robots::MotorI2C motor;
+    Robots::Norbot motor;
     
     // Initialise GeNN
     allocateMem();

--- a/stone_cx/simulatorVicon.cc
+++ b/stone_cx/simulatorVicon.cc
@@ -5,7 +5,7 @@
 // Common includes
 #include "../common/joystick.h"
 #include "../genn_utils/analogue_csv_recorder.h"
-#include "../robots/motor_i2c.h"
+#include "../robots/norbot.h"
 #include "../vicon/capture_control.h"
 #include "../vicon/udp.h"
 
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
     Joystick joystick;
 
     // Create motor interface
-    Robots::MotorI2C motor;
+    Robots::Norbot motor;
 
     // Create VICON UDP interface
     Vicon::UDPClient<Vicon::ObjectDataVelocity> vicon(51001);

--- a/video/display.h
+++ b/video/display.h
@@ -55,7 +55,7 @@ public:
     {
         if (videoInput.needsUnwrapping()) {
             m_ShowUnwrapped = true;
-            auto unwrapper = videoInput.createDefaultUnwrapper(std::forward<Ts>(unwrapRes)...);
+            auto unwrapper = videoInput.createUnwrapper(std::forward<Ts>(unwrapRes)...);
             m_Unwrapper = std::unique_ptr<ImgProc::OpenCVUnwrap360>(
                     new ImgProc::OpenCVUnwrap360(std::move(unwrapper)));
         }

--- a/video/input.h
+++ b/video/input.h
@@ -37,7 +37,7 @@ public:
     }
 
     template<typename... Ts>
-    ImgProc::OpenCVUnwrap360 createDefaultUnwrapper(Ts &&... args)
+    ImgProc::OpenCVUnwrap360 createUnwrapper(Ts &&... args)
     {
         cv::Size unwrapRes(std::forward<Ts>(args)...);
 


### PR DESCRIPTION
This is just some small housekeeping changes. I've renamed the `createDefaultUnwrapper()` function to `createUnwrapper()` and I've renamed all the classes for the wheeled robots to drop the Motor* prefix, which didn't seem particularly helpful (apart from anything, we now have a `GeNNRobotics::Robots` namespace which makes the names less ambiguous). I've also renamed the header files and updated all the examples.

I renamed `Robots::MotorI2C` to `Robots::Norbot` as this seemed a bit clearer to me than `Robots::I2C` or `Robots::Arduino` etc. But it is a bit silly, so I'm happy to change to any other sensible alternative name.

I've also just reworked the examples in GeNN robotics to use the new joystick API in a separate PR. If you're happy with both of these PRs then I'll update the snapshot_bot code accordingly (and add in the display stuff) before merging them in.